### PR TITLE
Introduce inline-regex for slice processing. Closes #18

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -330,7 +330,7 @@ We also introduce the `strategy` in the config file.
               key: manager.probe.port
         ```
 
-    1. The emitted helm template (args section) will be
+    1. The emitted helm template will be
 
       ```yaml
           - args:

--- a/examples/README.md
+++ b/examples/README.md
@@ -283,3 +283,72 @@ We also introduce the `strategy` in the config file.
       - strategy: file-if
         key: sharedValues.promethues.enabled
     ```
+1.  `inline-regex`
+
+    Allows insertion of a templated value as part of an overall string, such as the value for a pod's command line argument
+
+    Consider the following snippet from the [memcached deployment](../examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-controller-manager-deployment.yaml) in the examples folder:
+
+    ```yaml
+        - args:
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=127.0.0.1:8080
+            - --leader-elect
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      ```
+
+    You want to template the probe port. It therefore needs to be templated in the `args` section and also at `port` for each of `readinessProbe` and `livenessProbe`
+
+    This is how to do it.
+
+    1.  Edit the kustohelmize config file
+    1.  Set up the deployment's config like this
+
+        ```yaml
+        fileConfig:
+          deployments/memcached-operator-generated/memcached-operator-controller-manager-deployment.yaml:
+            spec.template.spec.containers[1].args:
+            - strategy: inline-regex
+              key: manager.probe.port
+              regex: --health-probe-bind-address=:(/d+)
+            spec.template.spec.containers[1].readinessProbe.httpGet.port:
+            - strategy: inline
+              key: manager.probe.port
+            spec.template.spec.containers[1].livenessProbe.httpGet.port:
+            - strategy: inline
+              key: manager.probe.port
+        ```
+
+    1. The emitted helm template (args section) will be
+
+      ```yaml
+          - args:
+              - --health-probe-bind-address=:{{ .Values.memcachedOperatorControllerManagerDeployment.manager.probe.port }}
+              - --metrics-bind-address=127.0.0.1:8080
+              - --leader-elect
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: {{ .Values.memcachedOperatorControllerManagerDeployment.manager.probe.port }}
+              initialDelaySeconds: 15
+              periodSeconds: 20
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: {{ .Values.memcachedOperatorControllerManagerDeployment.manager.probe.port }}
+              initialDelaySeconds: 5
+              periodSeconds: 10
+      ```
+
+    The match group in the regex `(\d+)` is templated with the `.Values` identified by `key`. Currently only one replacement per list item is possible.

--- a/examples/memcached-operator/config/crd/bases/cache.example.com_memcacheds.yaml
+++ b/examples/memcached-operator/config/crd/bases/cache.example.com_memcacheds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: memcacheds.cache.example.com
 spec:

--- a/examples/memcached-operator/config/manager/kustomization.yaml
+++ b/examples/memcached-operator/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: controller
+  newTag: latest

--- a/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-controller-manager-deployment.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-controller-manager-deployment.yaml
@@ -2,6 +2,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: memcached-operator
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/part-of: memcached-operator
     control-plane: controller-manager
   name: memcached-operator-controller-manager
   namespace: memcached-operator-system
@@ -17,13 +23,29 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+                - ppc64le
+                - s390x
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -38,6 +60,9 @@ spec:
             memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
       - args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
@@ -67,6 +92,9 @@ spec:
             memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
       securityContext:
         runAsNonRoot: true
       serviceAccountName: memcached-operator-controller-manager

--- a/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-controller-manager-metrics-service-svc.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-controller-manager-metrics-service-svc.yaml
@@ -2,6 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: memcached-operator
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: memcached-operator
     control-plane: controller-manager
   name: memcached-operator-controller-manager-metrics-service
   namespace: memcached-operator-system

--- a/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-controller-manager-sa.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-controller-manager-sa.yaml
@@ -1,5 +1,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: memcached-operator
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/part-of: memcached-operator
   name: memcached-operator-controller-manager
   namespace: memcached-operator-system

--- a/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-leader-election-role-role.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-leader-election-role-role.yaml
@@ -1,6 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: memcached-operator
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: role
+    app.kubernetes.io/part-of: memcached-operator
   name: memcached-operator-leader-election-role
   namespace: memcached-operator-system
 rules:

--- a/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-leader-election-rolebinding-rb.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-leader-election-rolebinding-rb.yaml
@@ -1,6 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: memcached-operator
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/part-of: memcached-operator
   name: memcached-operator-leader-election-rolebinding
   namespace: memcached-operator-system
 roleRef:

--- a/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-manager-rolebinding-crb.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-manager-rolebinding-crb.yaml
@@ -1,6 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: memcached-operator
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: memcached-operator
   name: memcached-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-metrics-reader-cr.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-metrics-reader-cr.yaml
@@ -1,6 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: memcached-operator
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: memcached-operator
   name: memcached-operator-metrics-reader
 rules:
 - nonResourceURLs:

--- a/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-proxy-role-cr.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-proxy-role-cr.yaml
@@ -1,6 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: memcached-operator
+    app.kubernetes.io/instance: proxy-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: memcached-operator
   name: memcached-operator-proxy-role
 rules:
 - apiGroups:

--- a/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-proxy-rolebinding-crb.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-proxy-rolebinding-crb.yaml
@@ -1,6 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: memcached-operator
+    app.kubernetes.io/instance: proxy-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: memcached-operator
   name: memcached-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-system-namespace.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator-generated/memcached-operator-system-namespace.yaml
@@ -2,5 +2,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: memcached-operator
+    app.kubernetes.io/instance: system
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: namespace
+    app.kubernetes.io/part-of: memcached-operator
     control-plane: controller-manager
   name: memcached-operator-system

--- a/examples/memcached-operator/deployments/memcached-operator.config
+++ b/examples/memcached-operator/deployments/memcached-operator.config
@@ -29,12 +29,23 @@ fileConfig:
       key: manager.image.tag
       value: latest
     spec.template.spec.containers[1].name:
-    - strategy: newline
+    - strategy: inline
       key: manager.name
       value: manager
     spec.template.spec.containers[1].resources:
     - strategy: control-with
       key: sharedValues.resources
+    spec.template.spec.containers[1].args:
+    - strategy: inline-regex
+      key: manager.probe.port
+      regex: --health-probe-bind-address=:(\d+)
+      value: 9010
+    spec.template.spec.containers[1].readinessProbe.httpGet.port:
+    - strategy: inline
+      key: manager.probe.port
+    spec.template.spec.containers[1].livenessProbe.httpGet.port:
+    - strategy: inline
+      key: manager.probe.port
   deployments/memcached-operator-generated/memcached-operator-controller-manager-metrics-service-svc.yaml: {}
   deployments/memcached-operator-generated/memcached-operator-controller-manager-sa.yaml: {}
   deployments/memcached-operator-generated/memcached-operator-leader-election-role-role.yaml: {}

--- a/examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-controller-manager-deployment.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-controller-manager-deployment.yaml
@@ -18,9 +18,25 @@ spec:
       labels: 
         control-plane: controller-manager
     spec: 
+      affinity: 
+        nodeAffinity: 
+          requiredDuringSchedulingIgnoredDuringExecution: 
+            nodeSelectorTerms:               
+              - matchExpressions:                   
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values: 
+                      - amd64
+                      - arm64
+                      - ppc64le
+                      - s390x
+                  - key: kubernetes.io/os
+                    operator: In
+                    values: 
+                      - linux
       containers:         
         - name: kube-rbac-proxy
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
           args: 
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
@@ -39,25 +55,27 @@ spec:
               memory: 64Mi
           securityContext: 
             allowPrivilegeEscalation: false
-        - name:
-            {{- .Values.memcachedOperatorControllerManagerDeployment.manager.name | nindent 12 }}
+            capabilities: 
+              drop: 
+                - ALL
+        - name: {{ .Values.memcachedOperatorControllerManagerDeployment.manager.name }}
           image: "{{ .Values.memcachedOperatorControllerManagerDeployment.manager.image.repository }}:{{ .Values.memcachedOperatorControllerManagerDeployment.manager.image.tag }}"
           command: 
             - /manager
           args: 
-            - --health-probe-bind-address=:8081
+            - --health-probe-bind-address=:{{ .Values.memcachedOperatorControllerManagerDeployment.manager.probe.port }}
             - --metrics-bind-address=127.0.0.1:8080
             - --leader-elect
           livenessProbe: 
             httpGet: 
               path: /healthz
-              port: 8081
+              port: {{ .Values.memcachedOperatorControllerManagerDeployment.manager.probe.port }}
             initialDelaySeconds: 15
             periodSeconds: 20
           readinessProbe: 
             httpGet: 
               path: /readyz
-              port: 8081
+              port: {{ .Values.memcachedOperatorControllerManagerDeployment.manager.probe.port }}
             initialDelaySeconds: 5
             periodSeconds: 10
           {{- with .Values.resources }}
@@ -66,6 +84,9 @@ spec:
           {{- end }}
           securityContext: 
             allowPrivilegeEscalation: false
+            capabilities: 
+              drop: 
+                - ALL
       securityContext: 
         runAsNonRoot: true
       serviceAccountName: memcached-operator-controller-manager

--- a/examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-controller-manager-sa.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-controller-manager-sa.yaml
@@ -4,3 +4,5 @@ kind: ServiceAccount
 metadata: 
   name: memcached-operator-controller-manager
   namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "memcached-operator.labels" . | nindent 4 }}

--- a/examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-leader-election-role-role.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-leader-election-role-role.yaml
@@ -4,6 +4,8 @@ kind: Role
 metadata: 
   name: memcached-operator-leader-election-role
   namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "memcached-operator.labels" . | nindent 4 }}
 rules:   
   - apiGroups: 
       - ""

--- a/examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-leader-election-rolebinding-rb.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-leader-election-rolebinding-rb.yaml
@@ -4,6 +4,8 @@ kind: RoleBinding
 metadata: 
   name: memcached-operator-leader-election-rolebinding
   namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "memcached-operator.labels" . | nindent 4 }}
 roleRef: 
   kind: Role
   apiGroup: rbac.authorization.k8s.io

--- a/examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-manager-rolebinding-crb.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-manager-rolebinding-crb.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata: 
   name: memcached-operator-manager-rolebinding
+  labels:
+    {{- include "memcached-operator.labels" . | nindent 4 }}
 roleRef: 
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-metrics-reader-cr.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-metrics-reader-cr.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata: 
   name: memcached-operator-metrics-reader
+  labels:
+    {{- include "memcached-operator.labels" . | nindent 4 }}
 rules:   
   - nonResourceURLs: 
       - /metrics

--- a/examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-proxy-role-cr.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-proxy-role-cr.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata: 
   name: memcached-operator-proxy-role
+  labels:
+    {{- include "memcached-operator.labels" . | nindent 4 }}
 rules:   
   - apiGroups: 
       - authentication.k8s.io

--- a/examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-proxy-rolebinding-crb.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator/templates/memcached-operator-proxy-rolebinding-crb.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata: 
   name: memcached-operator-proxy-rolebinding
+  labels:
+    {{- include "memcached-operator.labels" . | nindent 4 }}
 roleRef: 
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/examples/memcached-operator/deployments/memcached-operator/values.yaml
+++ b/examples/memcached-operator/deployments/memcached-operator/values.yaml
@@ -14,6 +14,8 @@ memcachedOperatorControllerManagerDeployment:
       repository: controller
       tag: latest
     name: manager
+    probe:
+      port: 9010
   replicas: 1
 memcachedOperatorControllerManagerMetricsServiceSvc: {}
 memcachedOperatorControllerManagerSa: {}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/yeahdongcn/kustohelmize
 go 1.18
 
 require (
+	github.com/dlclark/regexp2 v1.9.0
 	github.com/go-logr/logr v1.2.3
 	github.com/iancoleman/strcase v0.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dlclark/regexp2 v1.9.0 h1:pTK/l/3qYIKaRXuHnEnIf7Y5NxfRPfpb7dis6/gdlVI=
+github.com/dlclark/regexp2 v1.9.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -157,6 +157,9 @@ func (cc *ChartConfig) Values() (string, error) {
 					if i < len(substrings)-1 {
 						configRoot = configRoot[substring].(GenericMap)
 					} else {
+						if configRoot[substring] != nil && v[0].Value == nil {
+							c.Value = configRoot[substring]
+						}
 						if c.Value == nil {
 							cc.Logger.Info(fmt.Sprintf("%s: %s", c.Key, "nil"))
 							delete(configRoot, substring)
@@ -221,8 +224,10 @@ func (c *ChartConfig) GetFormattedKeyWithDefaultValue(xc *XPathConfig, prefix st
 }
 
 func (c *ChartConfig) Validate() error {
-	// Currently validate that file-if can only be present at root level file configs
-	// and that globalConfig cannot contain a root level entry
+	// Validates
+	// - file-if can only be present at root level file configs
+	// - globalConfig cannot contain a root level entry
+	// - inline-regex must have regex property, and the regex must compile and contain exactly one capture group
 	if _, ok := c.GlobalConfig[XPathRoot]; ok {
 		return fmt.Errorf("cannot have root level config in GlobalConfig")
 	}

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -1,1 +1,41 @@
 package template
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/dlclark/regexp2"
+	"github.com/stretchr/testify/require"
+)
+
+type regexTest struct {
+	expression  string
+	input       string
+	replacement string
+	expected    string
+}
+
+func TestRegexReplace(t *testing.T) {
+
+	testCases := []regexTest{
+		{
+			expression:  `--metrics-bind-address=127.0.0.1:(\d+)`,
+			input:       "--metrics-bind-address=127.0.0.1:1234",
+			replacement: "8081",
+			expected:    "--metrics-bind-address=127.0.0.1:8081",
+		},
+		{
+			expression:  `--metrics-bind-address=127.0.0.1:(\d+)-1234`,
+			input:       "--metrics-bind-address=127.0.0.1:1234-1234",
+			replacement: "{{ .Values.myoperator.manager.metrics.port }}",
+			expected:    "--metrics-bind-address=127.0.0.1:{{ .Values.myoperator.manager.metrics.port }}-1234",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("%s <- %s", testCase.expression, testCase.replacement), func(t *testing.T) {
+			rx := regexp2.MustCompile(testCase.expression, regexp2.Multiline)
+			require.Equal(t, testCase.expected, mustReplace(rx, testCase.input, testCase.replacement))
+		})
+	}
+}


### PR DESCRIPTION
New strategy `inline-regex` allows for the replacement of partial values in slices such as `cmd` and `args`

I noted your comment that you don't process slices into maps, but wondered how that might work well for arguments that don't have a value (like bool switches) and arguments that might have multiple (e.g. comma separated) values and you only want to change one of these values. Also other slices that don't represent arguments.

There may be a case where this strategy could be extended to map values, like partially replacing the value of an annotation.

