### PR TITLE
Examples README: Correct regex syntax and add port

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -321,7 +321,8 @@ We also introduce the `strategy` in the config file.
             spec.template.spec.containers[1].args:
             - strategy: inline-regex
               key: manager.probe.port
-              regex: --health-probe-bind-address=:(/d+)
+              regex: --health-probe-bind-address=:(\d+)
+              value: 9010
             spec.template.spec.containers[1].readinessProbe.httpGet.port:
             - strategy: inline
               key: manager.probe.port


### PR DESCRIPTION
We both missed this in the review :smile:

1. Invalid regex syntax
2. Include port number value

It is now aligned with the generated files pushed with the last PR.